### PR TITLE
Load Gazetteer Data into Database, Support Multiple Gazetteer Years

### DIFF
--- a/census_data/cli.py
+++ b/census_data/cli.py
@@ -233,7 +233,7 @@ def create_sqlite_load_cmd(input_csv, database_path, table_name=None):
         [f"  --type {c} {get_column_type(c)} \\" for c in data.columns]
     )
     load_cmd = (
-        f"sqlite-utils insert --csv --pk geoid {database_path} {table_name} {input_csv.name} \\\n"
+        f"sqlite-utils insert --csv --truncate --pk geoid {database_path} {table_name} {input_csv.name} \\\n"
         f"&& sqlite-utils transform {database_path} {table_name} \\\n"
         f"{type_options}"
     )

--- a/etl/employment_sql.mk
+++ b/etl/employment_sql.mk
@@ -1,7 +1,7 @@
 # Load ACS tables related to employment into a SQL database
 
 $(TABLE_PROXY_DIR)/acs5_2019_occupation_places: $(DATA_DIR_PROCESSED)/acs5_2019_occupation_places.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \
@@ -338,7 +338,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_occupation_places: $(DATA_DIR_PROCESSED)/acs5_2019_
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_occupation_counties: $(DATA_DIR_PROCESSED)/acs5_2019_occupation_counties.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \
@@ -675,7 +675,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_occupation_counties: $(DATA_DIR_PROCESSED)/acs5_201
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_occupation_states: $(DATA_DIR_PROCESSED)/acs5_2019_occupation_states.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \
@@ -1012,7 +1012,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_occupation_states: $(DATA_DIR_PROCESSED)/acs5_2019_
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_employmentstatus_places: $(DATA_DIR_PROCESSED)/acs5_2019_employmentstatus_places.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \
@@ -1049,7 +1049,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_employmentstatus_places: $(DATA_DIR_PROCESSED)/acs5
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_employmentstatus_counties: $(DATA_DIR_PROCESSED)/acs5_2019_employmentstatus_counties.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \
@@ -1086,7 +1086,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_employmentstatus_counties: $(DATA_DIR_PROCESSED)/ac
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_employmentstatus_states: $(DATA_DIR_PROCESSED)/acs5_2019_employmentstatus_states.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \
@@ -1123,7 +1123,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_employmentstatus_states: $(DATA_DIR_PROCESSED)/acs5
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_classofworker_places: $(DATA_DIR_PROCESSED)/acs5_2019_classofworker_places.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \
@@ -1226,7 +1226,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_classofworker_places: $(DATA_DIR_PROCESSED)/acs5_20
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_classofworker_counties: $(DATA_DIR_PROCESSED)/acs5_2019_classofworker_counties.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \
@@ -1329,7 +1329,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_classofworker_counties: $(DATA_DIR_PROCESSED)/acs5_
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_classofworker_states: $(DATA_DIR_PROCESSED)/acs5_2019_classofworker_states.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	--type geoid text \
 	--type name text \

--- a/etl/gazetteer.mk
+++ b/etl/gazetteer.mk
@@ -13,10 +13,15 @@ define GAZETTEER_DATASET_RULES
 # Files are touched after unzipping to freshen their dates, so that they are newer than the source .zip file.
 # `unzip` sets the file timestamp to match the time within the zip file. This would result in the `unzip` recipe
 # running every time (due to its .zip dependency being out of date).
+#
+# Generates a rule like:
+#     $(DATA_DIR_SRC)/2019_Gaz_counties_national.txt:
 $(DATA_DIR_SRC)/$(1)_Gaz_$(2).txt: $(DATA_DIR_SRC)/$(1)_Gaz_$(2).zip
 	unzip -o $$< $$(notdir $$@) -d $$(dir $$@)
 	touch --no-create $$@
 
+# Generates a rule like:
+#     $(DATA_DIR_SRC)/2019_Gaz_counties_national.zip:
 $(DATA_DIR_SRC)/$(1)_Gaz_$(2).zip: | $(DATA_DIR_SRC)
 	wget -O $$(@) https://www2.census.gov/geo/docs/maps-data/data/gazetteer/$1_Gazetteer/$1_Gaz_$2.zip
 endef

--- a/etl/gazetteer.mk
+++ b/etl/gazetteer.mk
@@ -3,32 +3,29 @@
 GAZETTEER_AREA_TYPES = counties_national cosubs_national place_national
 GAZETTEER_YEARS = 2019 2020 2021
 
-# Defines list of Gazetteer Files that are available for the defined
-# area types and years. Files in this list have the directory
-# prefix "$(YEAR)_Gazetteer/", which is how the files are stored
-# on census.gov.
-# This pattern is carried forward when storing them in the raw data
-# directory because there is no trivial way to flatten the file structure
-# on disk (in $(DATA_DIR_SRC)), but maintain it in the wget call.
-GAZETTEER_FILES_ZIPS = $(foreach YEAR, $(GAZETTEER_YEARS),  \
-					    $(foreach TYPE, $(GAZETTEER_AREA_TYPES), \
-    					$(YEAR)_Gazetteer/$(YEAR)_Gaz_$(TYPE).zip \
-	    				) \
-		    		   )
-GAZETTEER_FILES_TXT = $(GAZETTEER_FILES_ZIPS:.zip=.txt)
-
+define GAZETTEER_DATASET_RULES 
+# GAZETTEER_DATASET_RULES - Targets for downloading and extracting raw
+# gazetteer datasets.
+# Parameters:
+#   - $1 = Year
+#   - $2 = Area Type
+#
 # Files are touched after unzipping to freshen their dates, so that they are newer than the source .zip file.
 # `unzip` sets the file timestamp to match the time within the zip file. This would result in the `unzip` recipe
 # running every time (due to its .zip dependency being out of date).
-$(addprefix $(DATA_DIR_SRC)/,$(GAZETTEER_FILES_TXT)): %.txt: %.zip
-	unzip -o $< $(notdir $@) -d $(dir $@)
-	touch --no-create $@
+$(DATA_DIR_SRC)/$(1)_Gaz_$(2).txt: $(DATA_DIR_SRC)/$(1)_Gaz_$(2).zip
+	unzip -o $$< $$(notdir $$@) -d $$(dir $$@)
+	touch --no-create $$@
 
-# Because raw Gazetteer files are stored in a hierarchy that matches
-# the URL on census.gov, a `mkdir` is performed to ensure the destination
-# sub-directory exists.
-# The $(patubst) call removes the $(DATA_DIR_SRC) prefix from the target name.
-$(addprefix $(DATA_DIR_SRC)/,$(GAZETTEER_FILES_ZIPS)): | $(DATA_DIR_SRC)
-	mkdir -p "$(dir $@)"
-	wget -O $@ https://www2.census.gov/geo/docs/maps-data/data/gazetteer/$(patsubst $(DATA_DIR_SRC)/%,%,$@)
+$(DATA_DIR_SRC)/$(1)_Gaz_$(2).zip: | $(DATA_DIR_SRC)
+	wget -O $$(@) https://www2.census.gov/geo/docs/maps-data/data/gazetteer/$1_Gazetteer/$1_Gaz_$2.zip
+endef
 
+# Create .txt and .zip rules for the Gazetteer Files that are available
+# in the defined area types and years. This creates rules in the form
+# of data/raw/2021_Gaz_place_national.txt.
+$(foreach YEAR, $(GAZETTEER_YEARS),  \
+  $(foreach TYPE, $(GAZETTEER_AREA_TYPES), \
+  $(eval $(call GAZETTEER_DATASET_RULES,$(YEAR),$(TYPE))) \
+  ) \
+)

--- a/etl/gazetteer.mk
+++ b/etl/gazetteer.mk
@@ -1,28 +1,34 @@
 # Gazetteer files
 
-# National Counties Gazetteer File
-$(DATA_DIR_SRC)/2019_Gaz_counties_national.zip: | $(DATA_DIR_SRC)
-	wget -O $@ https://www2.census.gov/geo/docs/maps-data/data/gazetteer/2019_Gazetteer/2019_Gaz_counties_national.zip
+GAZETTEER_AREA_TYPES = counties_national cosubs_national place_national
+GAZETTEER_YEARS = 2019 2020 2021
+
+# Defines list of Gazetteer Files that are available for the defined
+# area types and years. Files in this list have the directory
+# prefix "$(YEAR)_Gazetteer/", which is how the files are stored
+# on census.gov.
+# This pattern is carried forward when storing them in the raw data
+# directory because there is no trivial way to flatten the file structure
+# on disk (in $(DATA_DIR_SRC)), but maintain it in the wget call.
+GAZETTEER_FILES_ZIPS = $(foreach YEAR, $(GAZETTEER_YEARS),  \
+					    $(foreach TYPE, $(GAZETTEER_AREA_TYPES), \
+    					$(YEAR)_Gazetteer/$(YEAR)_Gaz_$(TYPE).zip \
+	    				) \
+		    		   )
+GAZETTEER_FILES_TXT = $(GAZETTEER_FILES_ZIPS:.zip=.txt)
 
 # Files are touched after unzipping to freshen their dates, so that they are newer than the source .zip file.
 # `unzip` sets the file timestamp to match the time within the zip file. This would result in the `unzip` recipe
 # running every time (due to its .zip dependency being out of date).
-$(DATA_DIR_SRC)/2019_Gaz_counties_national.txt: %.txt: %.zip
+$(addprefix $(DATA_DIR_SRC)/,$(GAZETTEER_FILES_TXT)): %.txt: %.zip
 	unzip -o $< $(notdir $@) -d $(dir $@)
 	touch --no-create $@
 
-# National County Subdivisions Gazetteer File
-$(DATA_DIR_SRC)/2019_Gaz_cousubs_national.zip: | $(DATA_DIR_SRC)
-	wget -O $@ https://www2.census.gov/geo/docs/maps-data/data/gazetteer/2019_Gazetteer/2019_Gaz_cousubs_national.zip
+# Because raw Gazetteer files are stored in a hierarchy that matches
+# the URL on census.gov, a `mkdir` is performed to ensure the destination
+# sub-directory exists.
+# The $(patubst) call removes the $(DATA_DIR_SRC) prefix from the target name.
+$(addprefix $(DATA_DIR_SRC)/,$(GAZETTEER_FILES_ZIPS)): | $(DATA_DIR_SRC)
+	mkdir -p "$(dir $@)"
+	wget -O $@ https://www2.census.gov/geo/docs/maps-data/data/gazetteer/$(patsubst $(DATA_DIR_SRC)/%,%,$@)
 
-$(DATA_DIR_SRC)/2019_Gaz_cousubs_national.txt: %.txt: %.zip
-	unzip -o $< $(notdir $@) -d $(dir $@)
-	touch --no-create $@
-
-# National Places Gazetteer File
-$(DATA_DIR_SRC)/2019_Gaz_place_national.zip: | $(DATA_DIR_SRC)
-	wget -O $@ https://www2.census.gov/geo/docs/maps-data/data/gazetteer/2019_Gazetteer/2019_Gaz_place_national.zip
-
-$(DATA_DIR_SRC)/2019_Gaz_place_national.txt: %.txt: %.zip
-	unzip -o $< $(notdir $@) -d $(dir $@)
-	touch --no-create $@

--- a/etl/gazetteer.mk
+++ b/etl/gazetteer.mk
@@ -4,10 +4,25 @@
 $(DATA_DIR_SRC)/2019_Gaz_counties_national.zip: | $(DATA_DIR_SRC)
 	wget -O $@ https://www2.census.gov/geo/docs/maps-data/data/gazetteer/2019_Gazetteer/2019_Gaz_counties_national.zip
 
+# Files are touched after unzipping to freshen their dates, so that they are newer than the source .zip file.
+# `unzip` sets the file timestamp to match the time within the zip file. This would result in the `unzip` recipe
+# running every time (due to its .zip dependency being out of date).
+$(DATA_DIR_SRC)/2019_Gaz_counties_national.txt: %.txt: %.zip
+	unzip -o $< $(notdir $@) -d $(dir $@)
+	touch --no-create $@
+
 # National County Subdivisions Gazetteer File
 $(DATA_DIR_SRC)/2019_Gaz_cousubs_national.zip: | $(DATA_DIR_SRC)
 	wget -O $@ https://www2.census.gov/geo/docs/maps-data/data/gazetteer/2019_Gazetteer/2019_Gaz_cousubs_national.zip
 
+$(DATA_DIR_SRC)/2019_Gaz_cousubs_national.txt: %.txt: %.zip
+	unzip -o $< $(notdir $@) -d $(dir $@)
+	touch --no-create $@
+
 # National Places Gazetteer File
 $(DATA_DIR_SRC)/2019_Gaz_place_national.zip: | $(DATA_DIR_SRC)
 	wget -O $@ https://www2.census.gov/geo/docs/maps-data/data/gazetteer/2019_Gazetteer/2019_Gaz_place_national.zip
+
+$(DATA_DIR_SRC)/2019_Gaz_place_national.txt: %.txt: %.zip
+	unzip -o $< $(notdir $@) -d $(dir $@)
+	touch --no-create $@

--- a/etl/gazetteer_sql.mk
+++ b/etl/gazetteer_sql.mk
@@ -1,0 +1,27 @@
+# Load Gazetteer data into a SQL database.
+
+# The table name used in the database begins with "gaz_" instead of matching the input filename
+# ("2019_"), so that the table name begins with a letter, so that the table name
+# does not need to be quoted when used in a SQL query.
+
+$(TABLE_PROXY_DIR)/gaz_2019_place_national: $(DATA_DIR_SRC)/2019_Gaz_place_national.txt | $(TABLE_PROXY_DIR)
+	@# Gazetteer files have trailing whitespace at the end of each line
+	@# which results in the colum name 'INTPTLONG                  '.
+	pipenv run bash -c ' \
+	    ./etl/trim_trailing_tsv_whitespace.py $< | \
+	    sqlite-utils insert --tsv \
+	        --pk GEOID $(SQLITE_DB_PATH) $(basename $(notdir $@)) -' \
+	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $@)) \
+	  --type USPS text \
+	  --type GEOID text \
+	  --type ANSICODE text \
+	  --type NAME text \
+	  --type LSAD text \
+	  --type FUNCSTAT text \
+	  --type ALAND float \
+	  --type AWATER float \
+	  --type ALAND_SQMI float \
+	  --type AWATER_SQMI float \
+	  --type INTPTLAT float \
+	  --type INTPTLONG float \
+	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $@));" > $@

--- a/etl/gazetteer_sql.mk
+++ b/etl/gazetteer_sql.mk
@@ -13,8 +13,6 @@ define GAZETTEER_LOAD_DATA_RULE
 #   - $1 = Year
 #   - $2 = Area Type
 $(TABLE_PROXY_DIR)/gaz_$1_$2: $(DATA_DIR_SRC)/$1_Gaz_$2.txt | $(TABLE_PROXY_DIR)
-	@echo "$$@"
-	@echo "$$^"
 	@# Gazetteer files have trailing whitespace at the end of each line
 	@# which results in the colum name 'INTPTLONG                  '.
 	pipenv run bash -c ' \

--- a/etl/gazetteer_sql.mk
+++ b/etl/gazetteer_sql.mk
@@ -4,7 +4,7 @@
 # ("2019_"), so that the table name begins with a letter, so that the table name
 # does not need to be quoted when used in a SQL query.
 
-$(TABLE_PROXY_DIR)/gaz_2019_place_national: $(DATA_DIR_SRC)/2019_Gaz_place_national.txt | $(TABLE_PROXY_DIR)
+$(TABLE_PROXY_DIR)/gaz_2019_place_national: $(DATA_DIR_SRC)/2019_Gazetteer/2019_Gaz_place_national.txt | $(TABLE_PROXY_DIR)
 	@# Gazetteer files have trailing whitespace at the end of each line
 	@# which results in the colum name 'INTPTLONG                  '.
 	pipenv run bash -c ' \

--- a/etl/gazetteer_sql.mk
+++ b/etl/gazetteer_sql.mk
@@ -4,14 +4,24 @@
 # ("2019_"), so that the table name begins with a letter, so that the table name
 # does not need to be quoted when used in a SQL query.
 
-$(TABLE_PROXY_DIR)/gaz_2019_place_national: $(DATA_DIR_SRC)/2019_Gazetteer/2019_Gaz_place_national.txt | $(TABLE_PROXY_DIR)
+GAZETTEER_AREA_TYPES = counties_national cosubs_national place_national
+GAZETTEER_YEARS = 2019 2020 2021
+
+define GAZETTEER_LOAD_DATA_RULE
+# GAZETTEER_LOAD_DATA_RULE - Load raw gazetteer dataset into database.
+# Parameters:
+#   - $1 = Year
+#   - $2 = Area Type
+$(TABLE_PROXY_DIR)/gaz_$1_$2: $(DATA_DIR_SRC)/$1_Gaz_$2.txt | $(TABLE_PROXY_DIR)
+	@echo "$$@"
+	@echo "$$^"
 	@# Gazetteer files have trailing whitespace at the end of each line
 	@# which results in the colum name 'INTPTLONG                  '.
 	pipenv run bash -c ' \
-	    ./etl/trim_trailing_tsv_whitespace.py $< | \
+	    ./etl/trim_trailing_tsv_whitespace.py $$< | \
 	    sqlite-utils insert --tsv \
-	        --pk GEOID $(SQLITE_DB_PATH) $(basename $(notdir $@)) -' \
-	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $@)) \
+	        --pk GEOID $(SQLITE_DB_PATH) $$(basename $$(notdir $$@)) -' \
+	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $$(basename $$(notdir $$@)) \
 	  --type USPS text \
 	  --type GEOID text \
 	  --type ANSICODE text \
@@ -24,4 +34,11 @@ $(TABLE_PROXY_DIR)/gaz_2019_place_national: $(DATA_DIR_SRC)/2019_Gazetteer/2019_
 	  --type AWATER_SQMI float \
 	  --type INTPTLAT float \
 	  --type INTPTLONG float \
-	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $@));" > $@
+	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $$(basename $$(notdir $$@));" > $$@
+endef
+
+$(foreach YEAR, $(GAZETTEER_YEARS),  \
+  $(foreach TYPE, $(GAZETTEER_AREA_TYPES), \
+  $(eval $(call GAZETTEER_LOAD_DATA_RULE,$(YEAR),$(TYPE))) \
+  ) \
+)

--- a/etl/gazetteer_sql.mk
+++ b/etl/gazetteer_sql.mk
@@ -17,7 +17,7 @@ $(TABLE_PROXY_DIR)/gaz_$1_$2: $(DATA_DIR_SRC)/$1_Gaz_$2.txt | $(TABLE_PROXY_DIR)
 	@# which results in the colum name 'INTPTLONG                  '.
 	pipenv run bash -c ' \
 	    ./etl/trim_trailing_tsv_whitespace.py $$< | \
-	    sqlite-utils insert --tsv \
+	    sqlite-utils insert --tsv --truncate \
 	        --pk GEOID $(SQLITE_DB_PATH) $$(basename $$(notdir $$@)) -' \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $$(basename $$(notdir $$@)) \
 	  --type USPS text \

--- a/etl/language_sql.mk
+++ b/etl/language_sql.mk
@@ -6,7 +6,7 @@
 # TODO: Figure out what to do about the slug being different, i.e.
 # `languagelongform2015` instead of `languagelongform`.
 $(TABLE_PROXY_DIR)/acs5_2015_languagelongform2015_tracts: $(DATA_DIR_PROCESSED)/acs5_2015_languagelongform2015_tracts.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type geoid text \
 	  --type name text \
@@ -506,7 +506,7 @@ $(TABLE_PROXY_DIR)/acs5_2015_languagelongform2015_tracts: $(DATA_DIR_PROCESSED)/
 
 # Table C16001: Language Spoken at Home, tracts 
 $(TABLE_PROXY_DIR)/acs5_2020_languageshortform_tracts: $(DATA_DIR_PROCESSED)/acs5_2020_languageshortform_tracts.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type geoid text \
 	  --type name text \
@@ -671,7 +671,7 @@ $(TABLE_PROXY_DIR)/acs5_2020_languageshortform_tracts: $(DATA_DIR_PROCESSED)/acs
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/acs5_2019_languageshortform_tracts: $(DATA_DIR_PROCESSED)/acs5_2019_languageshortform_tracts.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type geoid text \
 	  --type name text \

--- a/etl/popest_sql.mk
+++ b/etl/popest_sql.mk
@@ -1,7 +1,7 @@
 # Load population estimate data into a SQL database
 
 $(TABLE_PROXY_DIR)/pep_2019_population_states: $(DATA_DIR_PROCESSED)/pep_2019_population_states.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk state $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk state $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type name text \
 	  --type population float \
@@ -10,7 +10,7 @@ $(TABLE_PROXY_DIR)/pep_2019_population_states: $(DATA_DIR_PROCESSED)/pep_2019_po
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/pep_2019_population_counties: $(DATA_DIR_PROCESSED)/pep_2019_population_counties.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk state --pk county $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk state --pk county $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type name text \
 	  --type population float \
@@ -20,7 +20,7 @@ $(TABLE_PROXY_DIR)/pep_2019_population_counties: $(DATA_DIR_PROCESSED)/pep_2019_
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/pep_2019_population_places: $(DATA_DIR_PROCESSED)/pep_2019_population_places.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk state --pk place $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk state --pk place $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type name text \
 	  --type population float \

--- a/etl/race_sql.mk
+++ b/etl/race_sql.mk
@@ -1,6 +1,6 @@
 # Table B03002: Hispanic or Latino Origin by Race, tracts
 $(TABLE_PROXY_DIR)/acs5_2019_race_tracts: $(DATA_DIR_PROCESSED)/acs5_2019_race_tracts.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type geoid text \
 	  --type name text \
@@ -51,7 +51,7 @@ $(TABLE_PROXY_DIR)/acs5_2019_race_tracts: $(DATA_DIR_PROCESSED)/acs5_2019_race_t
 
 # Table B03002: Hispanic or Latino Origin by Race, zctas
 $(TABLE_PROXY_DIR)/acs5_2019_race_zctas: $(DATA_DIR_PROCESSED)/acs5_2019_race_zctas.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type geoid text \
 	  --type name text \

--- a/etl/responserate_sql.mk
+++ b/etl/responserate_sql.mk
@@ -1,7 +1,7 @@
 # Load self-response rates
 
 $(TABLE_PROXY_DIR)/responserate_2020_responserate_tracts: $(DATA_DIR_PROCESSED)/responserate_2020_responserate_tracts.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type avg_cumulative float \
 	  --type avg_cumulative_internet float \
@@ -26,7 +26,7 @@ $(TABLE_PROXY_DIR)/responserate_2020_responserate_tracts: $(DATA_DIR_PROCESSED)/
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@
 
 $(TABLE_PROXY_DIR)/responserate_2010_responserate_tracts: $(DATA_DIR_PROCESSED)/responserate_2010_responserate_tracts.csv | $(TABLE_PROXY_DIR)
-	pipenv run sqlite-utils insert --csv --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
+	pipenv run sqlite-utils insert --csv --truncate --pk geoid $(SQLITE_DB_PATH) $(basename $(notdir $<)) $< \
 	&& pipenv run sqlite-utils transform $(SQLITE_DB_PATH) $(basename $(notdir $<)) \
 	  --type cumulative float \
 	&& sqlite3 -csv $(SQLITE_DB_PATH) "SELECT COUNT(*) FROM $(basename $(notdir $<));" > $@

--- a/etl/sql.mk
+++ b/etl/sql.mk
@@ -19,6 +19,7 @@ TABLE_PROXY_DIR := $(DATA_DIR_PROCESSED)/db_tables
 include etl/boundaries_sql.mk
 include etl/employment_sql.mk
 include etl/language_sql.mk
+include etl/gazetteer_sql.mk
 include etl/popest_sql.mk
 include etl/race_sql.mk
 include etl/redistricting_sql.mk

--- a/etl/trim_trailing_tsv_whitespace.py
+++ b/etl/trim_trailing_tsv_whitespace.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import sys
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: trim_trailing_tsv_whitespace.py file.tsv", file=sys.stderr)
+        sys.exit(1)
+    with open(sys.argv[1], 'tr') as f:
+        for line in f:
+            print(line.rstrip())


### PR DESCRIPTION
### Load Gazetteer Data into Database, Support Multiple Gazetteer Years

This PR adds the following:
 * Support for arbitrary years of Gazetteer Data (2019, 2020, 2021 in this PR) and area types without repetition in `etl/gazetteer.mk`.
 * Adds target for importing Gazetteer data into the SQLite database. Because the raw .txt files (TSV files) have trailing whitespace on each line, there is a new Python script that trims off trailing whitespace. Without this, the final column (internal point longitude/INTPTLONG) field would be interpreted as text.

Note that this _does_ use `eval` and `define`, which does add indirection and make the Makefile less straight-forward. However, this does eliminate repeating the same rules over and over for each year/area type. The following make it difficult to avoid the use of eval:
 * The raw data files on census.gov are organized under "$(YEAR)_Gazetteer/$(YEAR)_Gaz_$(AREA).zip", but we want to flatten this into `data/raw/$(YEAR)_Gaz_$(AREA).zip`. There isn't a great way to maintain this hierarchy for the URL, but strip it off on the target name with pattern substitution, because you can only substitute _once_.
 * Naming the database tables as `gaz_$(YEAR)` when the source files are `$(YEAR)_Gaz` presents a similar substitution problem. I named the tables with the `gaz_` prefix so that the table wouldn't begin with a number, making the table name easier to use in SQL queries (without having to worry about quoting the table name).

## Testing
Retrieving data and populating database:
```
$ make data/processed/db_tables/gaz_2021_place_national
wget -O data/raw/2021_Gaz_place_national.zip https://www2.census.gov/geo/docs/maps-data/data/gazetteer/2021_Gazetteer/2021_Gaz_place_national.zip
unzip -o data/raw/2021_Gaz_place_national.zip 2021_Gaz_place_national.txt -d data/raw/
Archive:  data/raw/2021_Gaz_place_national.zip
  inflating: data/raw/2021_Gaz_place_national.txt  
touch --no-create data/raw/2021_Gaz_place_national.txt
data/processed/db_tables/gaz_2021_place_national
data/raw/2021_Gaz_place_national.txt
pipenv run bash -c ' ./etl/trim_trailing_tsv_whitespace.py data/raw/2021_Gaz_place_national.txt | sqlite-utils insert --tsv --pk GEOID census_data.db gaz_2021_place_national -'
 text --type ANSICODE text --type NAME text --type LSAD text --type FUNCSTAT text --type ALAND float --type AWATER float --type ALAND_SQMI float --type AWATER_SQMI float --type
_national;" > data/processed/db_tables/gaz_2021_place_national
```
Inspecting loading data:
```
$ sqlite3 census_data.db
sqlite> .schema gaz_2021_place_national
CREATE TABLE IF NOT EXISTS "gaz_2021_place_national" (
   [USPS] TEXT,
   [GEOID] TEXT PRIMARY KEY,
   [ANSICODE] TEXT,
   [NAME] TEXT,
   [LSAD] TEXT,
   [FUNCSTAT] TEXT,
   [ALAND] FLOAT,
   [AWATER] FLOAT,
   [ALAND_SQMI] FLOAT,
   [AWATER_SQMI] FLOAT,
   [INTPTLAT] FLOAT,
   [INTPTLONG] FLOAT
);

sqlite> select * from gaz_2021_place_national LIMIT 2;
AL|0100100|02582661|Abanda CDP|57|S|7764034.0|34284.0|2.998|0.013|33.091627|-85.527029
AL|0100124|02403054|Abbeville city|25|A|40255362.0|107642.0|15.543|0.042|31.564724|-85.259123
```